### PR TITLE
Some changes made according to the Printify API documents.

### DIFF
--- a/V1/Models/Shops/Products/Design.cs
+++ b/V1/Models/Shops/Products/Design.cs
@@ -27,10 +27,10 @@ namespace PrintifyApi.V1.Models.Shops.Products
         public string Type { get; set; }
 
         [JsonProperty("height")]
-        public int Height { get; set; }
+        public double Height { get; set; }
 
         [JsonProperty("width")]
-        public int Width { get; set; }
+        public double Width { get; set; }
 
     }
 }

--- a/V1/Models/Shops/Products/Image.cs
+++ b/V1/Models/Shops/Products/Image.cs
@@ -17,7 +17,7 @@ namespace PrintifyApi.V1.Models.Shops.Products
         public double Y { get; set; }
 
         [JsonProperty("angle")]
-        public double Angle { get; set; }
+        public int Angle { get; set; }
 
     }
 

--- a/V1/PrintifyApiClient.cs
+++ b/V1/PrintifyApiClient.cs
@@ -8,6 +8,7 @@ using PrintifyApi.V1.Models.Shops.Products;
 using PrintifyApi.V1.Models.Shops.Webhooks;
 using PrintifyApi.V1.Models.Uploads;
 using System.Collections.Specialized;
+using System.Net.Http.Headers;
 using System.Threading.RateLimiting;
 
 namespace PrintifyApi.V1;
@@ -334,13 +335,12 @@ public class PrintifyApiClient : HttpClient, IPrintifyApiClient
     public async Task<Product> CreateProductAsync(int shopId, Product product)
     {
         string route = $"/v1/shops/{shopId}/products.json";
-        StringContent requestContent = new(Newtonsoft.Json.JsonConvert.SerializeObject(product));
+        StringContent requestContent = new(Newtonsoft.Json.JsonConvert.SerializeObject(product), MediaTypeHeaderValue.Parse("text/json"));
         HttpResponseMessage resp = await PostAsync(route, requestContent);
         resp.EnsureSuccessStatusCode();
         string responseContent = await resp.Content.ReadAsStringAsync();
         return Newtonsoft.Json.JsonConvert.DeserializeObject<Product>(responseContent);
     }
-
 
     /// <summary>
     /// Update a product


### PR DESCRIPTION
According to the Printify API documents, modify the data type of "width" and "height" form "int" to "double", modify the data type of "angle" form "double" to "int" and modify the method "CreateProductAsync" to produce request using "text/json".